### PR TITLE
#150398507 Cache the nutritional_info dictionary in NutritionPlans

### DIFF
--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -32,6 +32,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils import translation
 from django.conf import settings
+from django.db.models.signals import post_save
 
 from wger.core.models import Language
 from wger.utils.constants import TWOPLACES
@@ -109,50 +110,55 @@ class NutritionPlan(models.Model):
         '''
         Sums the nutritional info of all items in the plan
         '''
-        use_metric = self.user.userprofile.use_metric
-        unit = 'kg' if use_metric else 'lb'
-        result = {'total': {'energy': 0,
-                            'protein': 0,
-                            'carbohydrates': 0,
-                            'carbohydrates_sugar': 0,
-                            'fat': 0,
-                            'fat_saturated': 0,
-                            'fibres': 0,
-                            'sodium': 0},
-                  'percent': {'protein': 0,
-                              'carbohydrates': 0,
-                              'fat': 0},
-                  'per_kg': {'protein': 0,
-                             'carbohydrates': 0,
-                             'fat': 0},
-                  }
+        cache_plan = cache.get('result'+str(self.id))
+        if cache_plan:
+            result  = cache.get('result'+str(self.id))
+        else:
+            use_metric = self.user.userprofile.use_metric
+            unit = 'kg' if use_metric else 'lb'
+            result = {'total': {'energy': 0,
+                                'protein': 0,
+                                'carbohydrates': 0,
+                                'carbohydrates_sugar': 0,
+                                'fat': 0,
+                                'fat_saturated': 0,
+                                'fibres': 0,
+                                'sodium': 0},
+                      'percent': {'protein': 0,
+                                  'carbohydrates': 0,
+                                  'fat': 0},
+                      'per_kg': {'protein': 0,
+                                 'carbohydrates': 0,
+                                 'fat': 0},
+                      }
 
-        # Energy
-        for meal in self.meal_set.select_related():
-            values = meal.get_nutritional_values(use_metric=use_metric)
-            for key in result['total'].keys():
-                result['total'][key] += values[key]
+            # Energy
+            for meal in self.meal_set.select_related():
+                values = meal.get_nutritional_values(use_metric=use_metric)
+                for key in result['total'].keys():
+                    result['total'][key] += values[key]
 
-        energy = result['total']['energy']
+            energy = result['total']['energy']
 
-        # In percent
-        if energy:
-            for key in result['percent'].keys():
-                result['percent'][key] = \
-                    result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
+            # In percent
+            if energy:
+                for key in result['percent'].keys():
+                    result['percent'][key] = \
+                        result['total'][key] * ENERGY_FACTOR[key][unit] / energy * 100
 
-        # Per body weight
-        weight_entry = self.get_closest_weight_entry()
-        if weight_entry:
-            for key in result['per_kg'].keys():
-                result['per_kg'][key] = result['total'][key] / weight_entry.weight
+            # Per body weight
+            weight_entry = self.get_closest_weight_entry()
+            if weight_entry:
+                for key in result['per_kg'].keys():
+                    result['per_kg'][key] = result['total'][key] / weight_entry.weight
 
-        # Only 2 decimal places, anything else doesn't make sense
-        for key in result.keys():
-            for i in result[key]:
-                result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+            # Only 2 decimal places, anything else doesn't make sense
+            for key in result.keys():
+                for i in result[key]:
+                    result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
 
-        return result
+            cache.set("result"+ str(self.id),result)
+            return result
 
     def get_closest_weight_entry(self):
         '''

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -110,9 +110,9 @@ class NutritionPlan(models.Model):
         '''
         Sums the nutritional info of all items in the plan
         '''
-        cache_plan = cache.get('result'+str(self.id))
+        cache_plan = cache.get('result' + str(self.id))
         if cache_plan:
-            result  = cache.get('result'+str(self.id))
+            result = cache.get('result' + str(self.id))
         else:
             use_metric = self.user.userprofile.use_metric
             unit = 'kg' if use_metric else 'lb'
@@ -157,7 +157,7 @@ class NutritionPlan(models.Model):
                 for i in result[key]:
                     result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
 
-            cache.set("result"+ str(self.id),result)
+            cache.set("result" + str(self.id), result)
             return result
 
     def get_closest_weight_entry(self):

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -32,7 +32,6 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils import translation
 from django.conf import settings
-from django.db.models.signals import post_save
 
 from wger.core.models import Language
 from wger.utils.constants import TWOPLACES
@@ -158,7 +157,7 @@ class NutritionPlan(models.Model):
                     result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
 
             cache.set("result" + str(self.id), result)
-            return result
+        return result
 
     def get_closest_weight_entry(self):
         '''

--- a/wger/nutrition/templates/plan/overview.html
+++ b/wger/nutrition/templates/plan/overview.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load staticfiles %}
+{% load cache %}
+
 
 {% block title %}{% trans "Your nutrition plans" %}{% endblock %}
 

--- a/wger/nutrition/tests/test_ingredient.py
+++ b/wger/nutrition/tests/test_ingredient.py
@@ -121,6 +121,7 @@ class AddIngredientTestCase(WorkoutManagerAddTestCase):
 @override_settings(CACHES={
     'default': {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        'TIMEOUT': 30 * 24 * 60 * 60,
     }
 })
 class IngredientDetailTestCase(WorkoutManagerTestCase):

--- a/wger/nutrition/tests/test_ingredient.py
+++ b/wger/nutrition/tests/test_ingredient.py
@@ -117,12 +117,12 @@ class AddIngredientTestCase(WorkoutManagerAddTestCase):
             ingredient = Ingredient.objects.get(pk=self.pk_after)
             self.assertEqual(ingredient.status, Ingredient.INGREDIENT_STATUS_PENDING)
 
+
 @override_settings(CACHES={
     'default': {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
     }
 })
-
 class IngredientDetailTestCase(WorkoutManagerTestCase):
     '''
     Tests the ingredient details page

--- a/wger/nutrition/tests/test_ingredient.py
+++ b/wger/nutrition/tests/test_ingredient.py
@@ -19,6 +19,7 @@ from decimal import Decimal
 
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 
 from wger.core.models import Language
 from wger.core.tests import api_base_test
@@ -116,6 +117,11 @@ class AddIngredientTestCase(WorkoutManagerAddTestCase):
             ingredient = Ingredient.objects.get(pk=self.pk_after)
             self.assertEqual(ingredient.status, Ingredient.INGREDIENT_STATUS_PENDING)
 
+@override_settings(CACHES={
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+})
 
 class IngredientDetailTestCase(WorkoutManagerTestCase):
     '''

--- a/wger/nutrition/tests/test_nutritional_calculations.py
+++ b/wger/nutrition/tests/test_nutritional_calculations.py
@@ -15,6 +15,7 @@
 
 import logging
 from decimal import Decimal
+from django.test import override_settings
 
 from wger.core.tests.base_testcase import WorkoutManagerTestCase
 from wger.nutrition import models
@@ -23,6 +24,11 @@ from wger.utils.constants import TWOPLACES
 logger = logging.getLogger(__name__)
 
 
+@override_settings(CACHES={
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+})
 class NutritionalValuesCalculationsTestCase(WorkoutManagerTestCase):
     '''
     Tests the nutritional values calculators in the different models

--- a/wger/nutrition/tests/test_plan.py
+++ b/wger/nutrition/tests/test_plan.py
@@ -14,6 +14,7 @@
 # along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
 
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 
 from wger.core.tests import api_base_test
 from wger.core.tests.base_testcase import WorkoutManagerDeleteTestCase
@@ -22,6 +23,11 @@ from wger.core.tests.base_testcase import WorkoutManagerTestCase
 from wger.nutrition.models import NutritionPlan
 
 
+@override_settings(CACHES={
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+})
 class PlanRepresentationTestCase(WorkoutManagerTestCase):
     '''
     Test the representation of a model

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -156,7 +156,7 @@ def view(request, id, use_cache=True):
     template_data['owner_user'] = user
     template_data['is_owner'] = is_owner
     template_data['show_shariff'] = is_owner
-    cache_plan = cache.get('result'+str(id))
+    cache_plan = cache.get('result' + str(id))
     if not cache_plan:
         template_data['nutritional_data'] = \
             plan.get_nutritional_values()

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -123,7 +123,7 @@ class PlanEditView(WgerFormMixin, UpdateView):
         return context
 
 
-def view(request, id,use_cache=True):
+def view(request, id, use_cache=True):
     '''
     Show the nutrition plan with the given ID
     '''
@@ -162,9 +162,7 @@ def view(request, id,use_cache=True):
             plan.get_nutritional_values()
     else:
         template_data['nutritional_data'] = cache_plan
-
-
-    return render(request,'plan/view.html', template_data)
+    return render(request, 'plan/view.html', template_data)
 
 
 @login_required

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -29,6 +29,7 @@ from django.core.urlresolvers import reverse, reverse_lazy
 from django.contrib.auth.decorators import login_required
 from django.utils.translation import ugettext_lazy, ugettext as _
 from django.views.generic import DeleteView, UpdateView
+from django.core.cache import cache
 
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4, cm
@@ -122,7 +123,7 @@ class PlanEditView(WgerFormMixin, UpdateView):
         return context
 
 
-def view(request, id):
+def view(request, id,use_cache=True):
     '''
     Show the nutrition plan with the given ID
     '''
@@ -145,8 +146,6 @@ def view(request, id):
 
     # Get the nutritional info
     template_data['plan'] = plan
-    template_data['nutritional_data'] = \
-        plan.get_nutritional_values()
 
     # Get the weight entry used
     template_data['weight_entry'] = plan.get_closest_weight_entry()
@@ -157,8 +156,15 @@ def view(request, id):
     template_data['owner_user'] = user
     template_data['is_owner'] = is_owner
     template_data['show_shariff'] = is_owner
+    cache_plan = cache.get('result'+str(id))
+    if not cache_plan:
+        template_data['nutritional_data'] = \
+            plan.get_nutritional_values()
+    else:
+        template_data['nutritional_data'] = cache_plan
 
-    return render(request, 'plan/view.html', template_data)
+
+    return render(request,'plan/view.html', template_data)
 
 
 @login_required

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -146,6 +146,8 @@ def view(request, id, use_cache=True):
 
     # Get the nutritional info
     template_data['plan'] = plan
+    template_data['nutritional_data'] = \
+    plan.get_nutritional_values()
 
     # Get the weight entry used
     template_data['weight_entry'] = plan.get_closest_weight_entry()
@@ -156,12 +158,6 @@ def view(request, id, use_cache=True):
     template_data['owner_user'] = user
     template_data['is_owner'] = is_owner
     template_data['show_shariff'] = is_owner
-    cache_plan = cache.get('result' + str(id))
-    if not cache_plan:
-        template_data['nutritional_data'] = \
-            plan.get_nutritional_values()
-    else:
-        template_data['nutritional_data'] = cache_plan
     return render(request, 'plan/view.html', template_data)
 
 

--- a/wger/nutrition/views/plan.py
+++ b/wger/nutrition/views/plan.py
@@ -147,7 +147,7 @@ def view(request, id, use_cache=True):
     # Get the nutritional info
     template_data['plan'] = plan
     template_data['nutritional_data'] = \
-    plan.get_nutritional_values()
+        plan.get_nutritional_values()
 
     # Get the weight entry used
     template_data['weight_entry'] = plan.get_closest_weight_entry()


### PR DESCRIPTION
## What does this PR do?

- cache the nutritional_info dictionary in NutritionPlans and add signals that delete the cache key everytime a NutritionPlan, Meal and MealItem is added, edited or deleted.


## Where should the Reviewer Start?

- models.py - Fètch nutritional plans from cache if empty, set cache

## What are the relevant tickets?

150398507